### PR TITLE
Fix: readdata() prototype

### DIFF
--- a/words_of_wisdom
+++ b/words_of_wisdom
@@ -34,7 +34,7 @@ New in 3.7: in Mustache templates, {{%variable}} serializes a variable as multi-
 New in 3.7: JSON output is canonical (keys in maps are always sorted).
 New in 3.7: new packages promises with pluggable backends.  See https://docs.cfengine.com/latest/reference-standard-library-package_modules.html for the package module protocol.
 New in 3.7: YAML support, see readyaml() and parseyaml() and readdata().
-New in 3.7: readdata("auto|YAML|JSON|CSV", "filename") will use the file extension in auto mode.
+New in 3.7: readdata("filename", "auto|YAML|JSON|CSV") will use the file extension in auto mode.
 New in 3.7: CSV read into data container with readcsv()
 New in 3.7: list_ifelse() function to make a slist through if/else logic.
 New in 3.7: if (same as ifvarclass) and unless universal promise attributes.


### PR DESCRIPTION
Arguments were reversed, ref: https://docs.cfengine.com/latest/reference-functions-readdata.html