### PR TITLE
Update topics to include knowledge of ob-cfengine3

### DIFF
--- a/topics.yml
+++ b/topics.yml
@@ -7,7 +7,7 @@
    - policy editor
    - ide
   topic: Editors and plugins to help you develop CFEngine policy: ask me about emacs, spacemacs, and vim
-  
+
 - keywords:
    - emacs
    - cfengine_el

--- a/topics.yml
+++ b/topics.yml
@@ -7,7 +7,7 @@
    - policy editor
    - ide
   topic: Editors and plugins to help you develop CFEngine policy: ask me about emacs, spacemacs, and vim
-
+  
 - keywords:
    - emacs
    - cfengine_el
@@ -15,8 +15,13 @@
 
 - keywords:
    - spacemacs
-  topic: Spacemacs (emacs with vim keybindings) includes a cfengine layer enabling syntax highlighting and on the fly syntax checking, auto-completion, and function prototyping http://spacemacs.org/layers/+tools/cfengine/README.html
+  topic: Spacemacs (emacs with vim keybindings) includes a cfengine layer enabling syntax highlighting, on the fly syntax checking, auto-completion, function prototyping, and execution of cfengine3 SRC blocks from org-mode: http://spacemacs.org/layers/+tools/cfengine/README.html
 
+- keywords:
+   - org-mode
+   - ob-cfengine3
+  topic: ob-cfengine3 allows you to execute cfengine3 SRC blocks inside of emacs/spacemacs org-mode documents: https://github.com/nickanderson/ob-cfengine3
+  
 - keywords:
    - best practices
   topic: CFEngine best practices: http://watson-wilson.ca/blog/tag/best-practices/ and https://github.com/atsaloli/cf-health-check


### PR DESCRIPTION
ob-cfengine3 is part of the cfengine layer in the develop branch of spacemacs.
It's also available for regular emacs users via melpa